### PR TITLE
fix: Modify getIsSomeRowsSelected to check value

### DIFF
--- a/packages/table-core/src/features/RowSelection.ts
+++ b/packages/table-core/src/features/RowSelection.ts
@@ -431,8 +431,9 @@ export const RowSelection: TableFeature = {
     }
 
     table.getIsSomeRowsSelected = () => {
-      const totalSelected = Object.keys(
-        table.getState().rowSelection ?? {}
+      const rowSelection = table.getState().rowSelection ?? {}
+      const totalSelected = Object.entries(rowSelection).filter(
+        ([_, selected]) => selected
       ).length
       return (
         totalSelected > 0 &&


### PR DESCRIPTION
Instead of checking the existence of keys, check if the row's value is explicitly true or false.